### PR TITLE
Add support for loading SSL materiel from PEM files.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ sourceSets {
 }
 
 repositories {
+    mavenCentral()
     maven {
         url  "http://dl.bintray.com/shanemcc/dflibs"
     }
@@ -24,6 +25,8 @@ repositories {
 
 dependencies {
     compile group: 'uk.org.dataforce.libs', name: 'logger', version: '0.1'
+    compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.56'
+    compile group: 'org.bouncycastle', name:  'bcpkix-jdk15on', version: '1.56'
 }
 
 jar {

--- a/src/com/dfbnc/sockets/ListenSocket.java
+++ b/src/com/dfbnc/sockets/ListenSocket.java
@@ -29,8 +29,6 @@ import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-
-import com.dfbnc.sockets.secure.SecureSocket;
 import uk.org.dataforce.libs.logger.Logger;
 
 /**


### PR DESCRIPTION
Add an alternative constructor to SSLContextManager that takes
paths to a cert file and priv key file, and parses the relevant
keys and certs out of them.

DFBnc/DFBnc#108